### PR TITLE
fix(chore): add tasks to clean up tmp files

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
     "start-dev": "npm-run-all -p webpack-server cncserver-simulator",
     "webpack-server": "webpack-dev-server --mode development",
     "cncserver-simulator": "node ./node_modules/cncserver --botType=axidraw",
+    "postcncserver-simulator": "npm run clean-up",
     "cncserver": "node ./node_modules/cncserver --botType=axidraw --serialPath=$(node get-port.js)",
+    "postcncserver": "npm run clean-up",
     "clean-up": "rm /tmp/app.cncserver"
   },
   "repository": {


### PR DESCRIPTION
The `cncserver` creates a temp file with limited access. Once I switch the user of my machine, it has no access to that file and won't spawn a new server.

Is there a way to run this tasks everytime the "start" or "start-dev" tasks are killed?